### PR TITLE
Fixed ticket 401; also fixed Solr URL for Darwin case (removed 'select')

### DIFF
--- a/adsabs/modules/bibutils/static/js/metrics.js
+++ b/adsabs/modules/bibutils/static/js/metrics.js
@@ -783,6 +783,11 @@ function size_plot_series(size)
 //function that shows the tooltip for the graph
 function showTooltip(x, y, contents) 
 {
+    if ($("#content").length > 0) {
+        TARGET = "#content";
+    } else {
+        TARGET = "body";
+    }
     $('<div id="tooltip">' + contents + '</div>').css( {
         position: 'absolute',
         display: 'none',
@@ -794,7 +799,7 @@ function showTooltip(x, y, contents)
         opacity: 0.90,
         'font-size':'0.9em',
         'font-weight':'bold',
-    }).appendTo("body").fadeIn(200);
+    }).appendTo(TARGET).fadeIn(200);
 }
 
 

--- a/adsabs/modules/bibutils/templates/metrics_results.html
+++ b/adsabs/modules/bibutils/templates/metrics_results.html
@@ -427,8 +427,8 @@
 				</div>
 				<div id="paperhist_legend" class="plot_legend"></div>
 				<div id="paperhist_buttons" class="plot_buttons">
-					View as <select onchange="show_plot_paperhist(this.value);"><option value="hist">Histogram</option><option value="points">Points</option><option value="lines">Lines</option></select>
-					Size <select onchange="size_plot_paperhist(this.value);"><option value="1">Default</option><option value="2">Large</option></select>
+					View as <select onchange="show_plot_paperhist(this.value);" class="input-small"><option value="hist">Histogram</option><option value="points">Points</option><option value="lines">Lines</option></select>
+					Size <select onchange="size_plot_paperhist(this.value);" class="input-small"><option value="1">Default</option><option value="2">Large</option></select>
 				</div>
 			</div>
 		{% endif %}
@@ -449,8 +449,8 @@
 			</div>
 			<div id="readshist_legend" class="plot_legend"></div>
 			<div id="readshist_buttons" class="plot_buttons">
-				View as <select onchange="show_plot_readshist(this.value);"><option value="hist">Histogram</option><option value="points">Points</option><option value="lines">Lines</option></select>
-				Size <select onchange="size_plot_readshist(this.value);"><option value="1">Default</option><option value="2">Large</option></select>
+				View as <select onchange="show_plot_readshist(this.value);" class="input-small"><option value="hist">Histogram</option><option value="points">Points</option><option value="lines">Lines</option></select>
+				Size <select onchange="size_plot_readshist(this.value);" class="input-small"><option value="1">Default</option><option value="2">Large</option></select>
 			</div>
 		</div>
 		<div id="citshist_wrap" class="wrapper plot_wrapper 
@@ -475,8 +475,8 @@
 			
 			<div id="citshist_legend" class="plot_legend"></div>
 			<div id="citshist_buttons" class="plot_buttons">
-				View as <select onchange="show_plot_citshist(this.value);"><option value="hist">Histogram</option><option value="points">Points</option><option value="lines">Lines</option></select>
-				Size <select onchange="size_plot_citshist(this.value);"><option value="1">Default</option><option value="2">Large</option></select>
+				View as <select onchange="show_plot_citshist(this.value);" class="input-small"><option value="hist">Histogram</option><option value="points">Points</option><option value="lines">Lines</option></select>
+				Size <select onchange="size_plot_citshist(this.value);" class="input-small"><option value="1">Default</option><option value="2">Large</option></select>
 			</div>
 		</div>
 		{% if results['mode'] == 'normal' %}
@@ -493,8 +493,8 @@
 				</div>
 				<div id="series_legend" class="plot_legend"></div>
 				<div id="series_buttons" class="plot_buttons">
-					View as <select onchange="show_plot_series(this.value);"><option value="points">Points</option><option value="lines">Lines</option></select>
-					Size <select onchange="size_plot_series(this.value);"><option value="1">Default</option><option value="2">Large</option></select>
+					View as <select onchange="show_plot_series(this.value);" class="input-small"><option value="points">Points</option><option value="lines">Lines</option></select>
+					Size <select onchange="size_plot_series(this.value);" class="input-small"><option value="1">Default</option><option value="2">Large</option></select>
 				</div>
 			</div>
 		{% endif %}

--- a/adsabs/modules/bibutils/utils.py
+++ b/adsabs/modules/bibutils/utils.py
@@ -53,7 +53,7 @@ class CitationHarvester(Process):
             fl= 'bibcode,property,reference'
             try:
                 if sys.platform == 'darwin':
-                    search_results = solr_req(config.SOLRQUERY_URL + '/select', q=q, fl=fl, rows=config.BIBUTILS_MAX_HITS)
+                    search_results = solr_req(config.SOLRQUERY_URL, q=q, fl=fl, rows=config.BIBUTILS_MAX_HITS)
                     result_field = 'response'
                 else:
                     result_field = 'results'
@@ -104,7 +104,7 @@ class DataHarvester(Process):
             fl = 'bibcode,reference,author_norm,property,read_count'
             try:
                 if sys.platform == 'darwin':
-                    search_results = solr_req(config.SOLRQUERY_URL + '/select', q=q, fl=fl, rows=config.BIBUTILS_MAX_HITS)
+                    search_results = solr_req(config.SOLRQUERY_URL, q=q, fl=fl, rows=config.BIBUTILS_MAX_HITS)
                     result_field = 'response'
                 else:
                     result_field = 'results'


### PR DESCRIPTION
Fixed ticket 401 (layout problem with metrics: improper sizing of divs with histograms)

Since the SOLRQUERY_URL now has '/select' in it, this had to be removed from the query URL in the Darwin case in 'utils.py'
