### PR TITLE
Changed citation source to point to Solr (config.BIBUTILS_CITATION_SOURCE)

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -258,13 +258,14 @@ class AppConfig(object):
     BIBUTILS_THRESHOLD_FREQUENCY = 1
     BIBUTILS_DEFAULT_SUGGESTIONS = 10
     BIBUTILS_DEFAULT_FORMAT = 'score'
-    BIBUTILS_CITATION_SOURCE = 'MONGO'
+    BIBUTILS_CITATION_SOURCE = 'SOLR'
     # configuration parameters for the metrics module
     METRICS_DEFAULT_MODELS = ['statistics','histograms','metrics','series']
     METRICS_THREADS = 8
     METRICS_MIN_BIBLIO_LENGTH = 5
     METRICS_CHUNK_SIZE = 100
     METRICS_MAX_HITS = 100000
+    METRICS_TMP_DIR = '/tmp'
     ADSDATA_MONGO_DATABASE = 'adsdata'
     ADSDATA_MONGO_HOST = "localhost"
     ADSDATA_MONGO_PORT = 27017


### PR DESCRIPTION
changed config.py so that citations will be retrieved via Solr. So, the citations shown in the results list will be consistent with those used in the metrics
