### PR TITLE
Ticket #467 (see Trac)

### DIFF
--- a/adsabs/modules/feedback/views.py
+++ b/adsabs/modules/feedback/views.py
@@ -22,7 +22,7 @@ def send_feedback(form):
     except:
         url_from = ''
     message_body = "Sent from url: %s \n\nMessage:\n%s" % (url_from, form.feedback_text.data)
-    msg = Message(u"ADSABS2 feedback: %s" % form.feedback_type.data,
+    msg = Message(u"ADSABS2 feedback from %s: %s" % (form.email.data, form.feedback_type.data),
                   body=message_body,
                   sender=form.email.data,
                   recipients=config.FEEDBACK_RECIPIENTS)

--- a/config/config.py
+++ b/config/config.py
@@ -212,7 +212,7 @@ class AppConfig(object):
     
     #sendmail configuration
     SMTP_HOST = 'localhost'
-    API_WELCOME_FROM_EMAIL = 'jluker@cfa.harvard.edu'
+    API_WELCOME_FROM_EMAIL = 'adshelp@cfa.harvard.edu'
     API_SIGNUP_SPREADSHEET_KEY = None
     API_SIGNUP_SPREADSHEET_LOGIN = None    
 


### PR DESCRIPTION
1. change config.API_WELCOME_FROM_EMAIL to general 'adshelp'
2. Subject line for ADS 2.0 feedback email will get user email in it:
   msg = Message(u"ADSABS2 feedback from %s: %s" % (form.email.data,
   form.feedback_type.data),
   body=message_body,
   sender=form.email.data,
   recipients=config.FEEDBACK_RECIPIENTS)
