### PR TITLE
Ticket 473: export with selection

### DIFF
--- a/adsabs/modules/abs/templates/macros/list_articles.html
+++ b/adsabs/modules/abs/templates/macros/list_articles.html
@@ -5,7 +5,8 @@
 
 {% macro render_list_articles(list_articles, list_type, bibcode) %}
 
-{% set query_components={'q':list_articles.request.get_param('q'), 'sort':(list_articles.request.get_param('sort').split(' ')[0], list_articles.request.get_param('sort').split(' ')[1])} %} 
+{# set query_components={'q':list_articles.request.get_param('q'), 'sort':(list_articles.request.get_param('sort').split(' ')[0], list_articles.request.get_param('sort').split(' ')[1])} #}
+{% set query_components={'q':list_articles.request.get_param('q') %}
 
 <form id="search_results_form" action="">
 	<input type="hidden" value='{{ query_components|tojson|safe }}' name="current_search_parameters" />


### PR DESCRIPTION
Export of references/citations failed because of the 'query_components' setting for 'sort' in the macro 'list_articles'.
