### PR TITLE
Ticket 452: metrics speedup by total overhaul

### DIFF
--- a/adsabs/modules/bibutils/biblio_functions.py
+++ b/adsabs/modules/bibutils/biblio_functions.py
@@ -13,7 +13,6 @@ from itertools import groupby
 from flask import current_app as app
 from config import config
 from utils import get_references
-from utils import get_citations
 from utils import get_citing_papers
 from utils import get_meta_data
  

--- a/adsabs/modules/bibutils/views.py
+++ b/adsabs/modules/bibutils/views.py
@@ -153,7 +153,7 @@ def metrics(**args):
     if len(bibcodes) > 0:
         # we have a list of bibcodes, so start working
         try:
-            results = generate_metrics(bibcodes=bibcodes, types='statistics,histograms,metrics,series', fmt=format)
+            results = generate_metrics(bibcodes=bibcodes, fmt=format)
         except Exception, err:
             app.logger.error('ID %s. Unable to get results! (%s)' % (g.user_cookie_id,err))
             return render_template('metrics_no_results.html', include_layout=layout)

--- a/config/config.py
+++ b/config/config.py
@@ -254,13 +254,18 @@ class AppConfig(object):
     BIBUTILS_DEFAULT_FORMAT = 'score'
     BIBUTILS_CITATION_SOURCE = 'MONGO'
     # configuration parameters for the metrics module
-    METRICS_DEFAULT_MODELS = ['statistics','histograms','metrics','series']
+    METRICS_DEFAULT_MODELS = 'statistics,histograms,metrics,series'
     METRICS_THREADS = 8
     METRICS_MIN_BIBLIO_LENGTH = 5
     METRICS_CHUNK_SIZE = 100
     METRICS_MAX_HITS = 100000
     METRICS_TMP_DIR = '/tmp'
-
+    METRICS_MONGO_HOST = 'localhost'
+    METRICS_MONGO_PORT = 27017
+    METRICS_DATABASE = 'metrics'
+    METRICS_COLLECTION = 'metrics_data'
+    METRICS_MONGO_USER = 'metrics'
+    METRICS_MONGO_PASSWORD = ''
     # config for the adsdata extension
     ADSDATA_MONGO_DATABASE = 'adsdata'
     ADSDATA_MONGO_HOST = "localhost"


### PR DESCRIPTION
Metrics machinery has been overhauled: most data is now retrieved from Mongo (especially citations, and pre-computed data). Currently the pre-computed data is in a separate collection on adsx and retrieved using pymongo. Add machinery like adsdata? Fold it into the adsdata machinery and have the data be part of the collection with aggregated data?
