### PR TITLE
bibutils unit test: removed get_citations test

### DIFF
--- a/tests/test_modules_bibutils.py
+++ b/tests/test_modules_bibutils.py
@@ -35,14 +35,6 @@ class TestCitationHelper(AdsabsBaseTestCase):
             self.app.preprocess_request()
             self.assertEqual(bf.get_suggestions(), [])
 
-    def test_citation_list(self):
-        import types
-        with self.app.test_request_context('/bibutils'):
-            self.app.preprocess_request()
-            cits = utils.get_citations(bibcodes=['1996ApJ...469..437S'])
-            self.assertEqual(type(cits),types.DictType)
-            self.assertTrue(len(cits)>0)
-
     def test_reference_list(self):
         import types
         with self.app.test_request_context('/bibutils'):


### PR DESCRIPTION
The get_citations function was removed from the bibutils module (so it needed to be removed from the unit tests too)
