### PR TITLE
Added metrics on abstract view

### DIFF
--- a/adsabs/modules/abs/templates/abstract_tabs.html
+++ b/adsabs/modules/abs/templates/abstract_tabs.html
@@ -3,7 +3,7 @@
 {% from "macros/abstract.html" import render_abstract, render_abstract_macro_tags with context %}
 {% from "macros/classic_log_request.html" import render_classic_log_request_js with context %}
 {# Global import #}
-{% from "macros/record_list_macros/button_menu.html" import render_export_menu with context %}
+{% from "macros/record_list_macros/button_menu.html" import render_export_menu, render_abstract_analyze_menu with context %}
 
 {% extends "layout.html" %}
 
@@ -24,6 +24,7 @@
 			<div class="dropdown pull-right">
 			    {% if curview == 'abstract'%}
 					{{ render_export_menu() }}
+	                {{ render_abstract_analyze_menu() }}
 				{% endif %}
 				</ul>
 			</div>

--- a/adsabs/static/js/record_list_functions.js
+++ b/adsabs/static/js/record_list_functions.js
@@ -200,3 +200,47 @@ ResultListManager.metrics = function()
                 }
         });
 };
+
+ResultListManager.single_metrics = function()
+{
+        $.fancybox.showLoading();
+        //re-enable query parameters
+        $('#search_results_form > input[name="current_search_parameters"]').removeAttr('disabled');
+        //remove a hidden fields if exists
+        $('#search_results_form > input.ajaxHiddenField').remove();
+        //if there are checked bibcodes
+        if ($('#search_results_form').find('input[name="bibcode"]:checked').length > 0)
+        {
+                //remove the query parameters
+                checked_bibcodes = new Array();
+                var $inputs = $('#search_results_form').find('input[name="bibcode"]:checked');
+                $inputs.each(function() {
+                    checked_bibcodes.push($(this).attr('value'));
+                });
+                var collapsed_bibcodes = checked_bibcodes.join('\n');
+                var original_query = "NA";
+        }
+        else
+        {
+                bibcodes = new Array();
+                var $inputs = $('#search_results_form').find('input[name="bibcode"]');
+                $inputs.each(function() {
+                    bibcodes.push($(this).attr('value'));
+                });
+                var collapsed_bibcodes = bibcodes.join('\n');
+        }
+        alert(collapsed_bibcodes);
+        $('#search_results_form > input[name="current_search_parameters"]').removeAttr('disabled');
+        $('#search_results_form').append('<input type="hidden" name="bibcodes" class="ajaxHiddenField" value="'+collapsed_bibcodes+'"/>');
+        //submit the form via ajax
+        $.ajax({
+                type : "POST",
+                cache : false,
+                url : GlobalVariables.ADSABS2_METRICS_BASE_URL,
+                data : $('#search_results_form').serializeArray(),
+                success: function(data) {
+                    $.fancybox.hideLoading();
+                    $.fancybox(data);
+                }
+        });
+};

--- a/adsabs/templates/macros/record_list_macros/button_menu.html
+++ b/adsabs/templates/macros/record_list_macros/button_menu.html
@@ -162,6 +162,17 @@
 </div>
 {% endmacro %}
 
+{# ###Macro to render analyze menu #}
+{% macro render_abstract_analyze_menu() %}
+<div class="export_view_menu dropdown pull-right">
+        <a class="btn dropdown-toggle" data-toggle="dropdown" ><i class="icon-wrench"></i> Analyze <i class="caret"></i></a>
+        <ul class="dropdown-menu">
+                <li class="nav-header">for this abstract:</li>
+                <li><a tabindex="-1" class="jslinkmenu" onclick="ResultListManager.single_metrics()">Metrics</a></li>
+        </ul>
+</div>
+{% endmacro %}
+
 {# ###Macro to render toggle all button #}
 {% macro render_toggle_all_paper_list() %}
 <span class="btn" data-rel="bootstrap_tooltip" title="Toggle all" onclick="$('input[type=checkbox][name=bibcode]').prop('checked', function() {return !$(this).prop('checked')});">


### PR DESCRIPTION
The abstract view now has an 'Analyze' dropdown menu. This contains a new function 'render_abstract_analyze_menu', which in turn uses a new function 'single_metrics' in 'record_list_functions.js'. This function grabs the bibcode in the hidden input box (with bibcode value 'selected') in the abstract page. So, essentially, the existing 'metrics' function could be used, but this way we have flexibility to change this down the line.
