### PR TITLE
Ticket 488: record selection ignored in metrics

### DIFF
--- a/adsabs/modules/bibutils/views.py
+++ b/adsabs/modules/bibutils/views.py
@@ -148,15 +148,20 @@ def metrics(**args):
         # make sure we have a list of what seem to be bibcodes
         query_bibcodes = []
         try:
-            query_par = str(form.current_search_parameters.data.strip())
-            query = json.loads(query_par)['q']
-            query_bibcodes = get_publications_from_query(query)
+            bibcodes = filter(lambda b: len(b) == 19, map(lambda a: str(a).strip(), form.bibcodes.data.strip().split('\n')))
         except:
-            pass
-        if len(query_bibcodes) == 0:
-            bibcodes = map(lambda a: str(a).strip(), form.bibcodes.data.strip().split('\n'))
-        else:
-            bibcodes = query_bibcodes[:config.METRICS_MAX_EXPORT]
+            bibcodes = []
+        if len(bibcodes) == 0:
+            try:
+                query_par = str(form.current_search_parameters.data.strip())
+                query = json.loads(query_par)['q']
+                bibcodes = get_publications_from_query(query)[:config.METRICS_MAX_EXPORT]
+            except:
+                bibcodes = []
+#        if len(query_bibcodes) == 0:
+#            bibcodes = map(lambda a: str(a).strip(), form.bibcodes.data.strip().split('\n'))
+#        else:
+#            bibcodes = query_bibcodes[:config.METRICS_MAX_EXPORT]
         bibcodes = filter(lambda a: len(a) == 19, bibcodes)
         # no bibcodes? display message and re-display input form
         if len(bibcodes) == 0:

--- a/adsabs/static/js/record_list_functions.js
+++ b/adsabs/static/js/record_list_functions.js
@@ -176,18 +176,12 @@ ResultListManager.metrics = function()
                 });
                 var collapsed_bibcodes = checked_bibcodes.join('\n');
                 var original_query = "NA";
+                $('#search_results_form').append('<input type="hidden" name="bibcodes" class="ajaxHiddenField" value="'+collapsed_bibcodes+'"/>');
         }
         else
         {
-                bibcodes = new Array();
-                var $inputs = $('#search_results_form').find('input[name="bibcode"]');
-                $inputs.each(function() {
-                    bibcodes.push($(this).attr('value'));
-                });
-                var collapsed_bibcodes = bibcodes.join('\n');
+                $('#search_results_form > input[name="current_search_parameters"]').removeAttr('disabled');
         }        
-        $('#search_results_form > input[name="current_search_parameters"]').removeAttr('disabled');
-        $('#search_results_form').append('<input type="hidden" name="bibcodes" class="ajaxHiddenField" value="'+collapsed_bibcodes+'"/>');
         //submit the form via ajax
         $.ajax({
                 type : "POST",


### PR DESCRIPTION
Even though records were selected, metrics calculation was done as if no records were selected. The Javascript function now only makes the query parameter visible and set no bibcodes, so that the views module finds no selected bibcodes and 'knows' that it needs to use the query
