### PR TITLE
ticket_387: bottom page links now point to something

### DIFF
--- a/adsabs/templates/footer.html
+++ b/adsabs/templates/footer.html
@@ -9,11 +9,10 @@
 		<p><a href="http://doc.adsabs.harvard.edu/abs_doc/help_pages/overview.html#use" target="_blank">Terms and Conditions</a></p>
 	</div>
 	<div class="span1">
-		<a href="#mirrors">Mirrors</a><br/>
+		<a href="http://adsabs.harvard.edu/mirrors.html">Mirrors</a><br/>
 		<a href="{{ url_for('feedback.feedback') }}">Feedback</a><br/>
-		<a href="#faq">FAQ</a><br/>
-		<a href="#sitemap">Site Map</a><br/>
-		<a href="#careers">Careers</a><br/>
+		<a href="{{ url_for('pages.page', page_path='help/') }}">FAQ</a><br/>
+		<!-- <a href="#sitemap">Site Map</a><br/> -->
 	</div>
 	<div class="span2">
 		<a href="http://www.si.edu" target="_blank">Smithsonian Institution</a><br/>


### PR DESCRIPTION
The 'mirrors' link point to the mirrors page on ADS Classic, the 'FAQ' point to the Help, the 'career' link has been removed and the 'sitemap' link has been disabled for now
