### PR TITLE
metrics from query: include sort order

### DIFF
--- a/adsabs/modules/bibutils/utils.py
+++ b/adsabs/modules/bibutils/utils.py
@@ -283,10 +283,10 @@ def get_references(**args):
                 papers += doc['reference']
     return papers
 
-def get_publications_from_query(q):
+def get_publications_from_query(q,sort_order):
     try:
         # Get the information from Solr
-        resp = solr.query(q, rows=config.BIBUTILS_MAX_HITS, fields=['bibcode'])
+        resp = solr.query(q, rows=config.BIBUTILS_MAX_HITS, fields=['bibcode'], sort=sort_order)
     except SolrReferenceQueryError, e:
         app.logger.error("Solr publications query for %s blew up (%s)" % (q,e))
         raise

--- a/adsabs/modules/bibutils/views.py
+++ b/adsabs/modules/bibutils/views.py
@@ -155,7 +155,8 @@ def metrics(**args):
             try:
                 query_par = str(form.current_search_parameters.data.strip())
                 query = json.loads(query_par)['q']
-                bibcodes = get_publications_from_query(query)[:config.METRICS_MAX_EXPORT]
+                sort  = json.loads(query_par)['sort']
+                bibcodes = get_publications_from_query(query, sort)[:config.METRICS_MAX_EXPORT]
             except:
                 bibcodes = []
 #        if len(query_bibcodes) == 0:


### PR DESCRIPTION
When no records are selected for metrics, the query is used to retrieve all relevant bibcodes. However, the sort order is currently ignored, which is wrong if people sort the results list (e.g. by date) and then retrieve metrics. So, now the sort order is retrieved from the search parameters and included when bibcodes are retrieved.
