### PR TITLE
Ticket 402: Help tooltips for metrics

### DIFF
--- a/adsabs/modules/bibutils/static/js/helptips.js
+++ b/adsabs/modules/bibutils/static/js/helptips.js
@@ -36,29 +36,15 @@ HelpTipManager.help_text['ROQ_INDEX'] = {'title':'riq-index', 'help': 'The riq-i
 HelpTipManager.help_text['M_INDEX'] = {'title':'m-index', 'help': 'The m-index is the h-index divided by the time (years) between the first and most recent publication.'};
 HelpTipManager.help_text['READ10_INDEX'] = {'title':'Read10-index', 'help': 'Read10 is the current readership rate for all an individual\'s papers published in the most recent ten years, normalized for number of authors.'};
 
-// function that shows an help text for the different options of a search page
-HelpTipManager.show_help = function(item)
-{
-    // Get the help text
-	var text_type = this.help_text[item.id];
-	// Create the Help tip using popover from bootstrap
-	$(item).popover({
-	    html: true,
-	    trigger: "hover focus",
-	    title: text_type['title'],
-	    content: text_type['help'],
-	});
-};
+HelpTipManager.get_content = function(id) {
+	return this.help_text[id];
+}
 
 $(document).ready(function(){
-    $('a.helptip_mark').mouseover(function (){
-        var id = $(this).attr('id');
-        var text_type = HelpTipManager.help_text[id];
-    	$(this).popover({
-	        html: true,
-	        trigger: "hover focus",
-	        title: text_type['title'],
-	        content: text_type['help'],
-    	});
-    });
+	$('.helptip_mark').popover({
+		html: true,
+		trigger: "hover focus",
+		title: function() { return HelpTipManager.get_content($(this).attr('id'))['title']; },
+		content: function() { return HelpTipManager.get_content($(this).attr('id'))['help']; }
+	});
 });

--- a/adsabs/modules/bibutils/templates/metrics_results.html
+++ b/adsabs/modules/bibutils/templates/metrics_results.html
@@ -47,7 +47,7 @@
 					<tr>
 						<td>Number of papers</td>
 						<td class="helptip">
-							[<a href="#" class="helptip_mark" id="NUMBER_OF_PAPERS" onmouseover="HelpTipManager.show_help(this);">?</a>]
+                            <i class="icon-question-sign helptip_mark" id="NUMBER_OF_PAPERS"></i>
 						</td>
 						<td>
 							{{results['all stats']['Number of papers']}}
@@ -61,7 +61,7 @@
 					<tr>
 						<td>Normalized paper count</td>
 						<td class="helptip">
-							[<a class="helptip_mark" id="NORMALIZED_PAPER_COUNT" onmouseover="HelpTipManager.show_help(this);">?</a>]
+                            <i class="icon-question-sign helptip_mark" id="NORMALIZED_PAPER_COUNT"></i>
 						</td>
 						<td>
 							{{results['all stats']['Normalized paper count']}}
@@ -74,7 +74,7 @@
 				<tr>
 					<td>Total reads</td>
 					<td class="helptip">
-						[<a class="helptip_mark" id="TOTAL_NUMBER_OF_READS" onmouseover="HelpTipManager.show_help(this);">?</a>]
+                        <i class="icon-question-sign helptip_mark" id="TOTAL_NUMBER_OF_READS"></i>
 					</td>
 					<td>
 						{{results['all reads']['Total number of reads']}}
@@ -90,7 +90,7 @@
 					<tr>
 						<td>Average reads</td>
 						<td class="helptip">
-							[<a class="helptip_mark" id="AVERAGE_NUMBER_OF_READS" onmouseover="HelpTipManager.show_help(this);">?</a>]
+                        <i class="icon-question-sign helptip_mark" id="AVERAGE_NUMBER_OF_READS"></i>
 						</td>
 						<td>
 							{{results['all reads']['Average number of reads']}}
@@ -102,7 +102,7 @@
 					<tr>
 						<td>Median reads</td>
 						<td class="helptip">
-							[<a class="helptip_mark" id="MEDIAN_NUMBER_OF_READS" onmouseover="HelpTipManager.show_help(this);">?</a>]
+                        <i class="icon-question-sign helptip_mark" id="MEDIAN_NUMBER_OF_READS"></i>
 						</td>
 						<td>
 							{{results['all reads']['Median number of reads']}}
@@ -115,7 +115,7 @@
 				<tr>
 					<td>Total downloads</td>
 					<td class="helptip">
-						[<a class="helptip_mark" id="TOTAL_NUMBER_OF_DOWNLOADS" onmouseover="HelpTipManager.show_help(this);">?</a>]
+                        <i class="icon-question-sign helptip_mark" id="TOTAL_NUMBER_OF_DOWNLOADS"></i>
 					</td>
 					<td>
 						{{results['all reads']['Total number of downloads']}}
@@ -130,7 +130,7 @@
 					<tr>
 						<td>Average downloads</td>
 						<td class="helptip">
-							[<a class="helptip_mark" id="AVERAGE_NUMBER_OF_DOWNLOADS" onmouseover="HelpTipManager.show_help(this);">?</a>]
+                        <i class="icon-question-sign helptip_mark" id="AVERAGE_NUMBER_OF_DOWNLOADS"></i>
 						</td>
 						<td>
 							{{results['all reads']['Average number of downloads']}}
@@ -142,7 +142,7 @@
 					<tr>
 						<td>Median downloads</td>
 						<td class="helptip">
-							[<a class="helptip_mark" id="MEDIAN_NUMBER_OF_DOWNLOADS" onmouseover="HelpTipManager.show_help(this);">?</a>]
+                        <i class="icon-question-sign helptip_mark" id="MEDIAN_NUMBER_OF_DOWNLOADS"></i>
 						</td>
 						<td>
 							{{results['all reads']['Median number of downloads']}}
@@ -180,7 +180,7 @@
 					<tr>
 						<td>Number of citing papers</td>
 						<td class="helptip">
-							[<a class="helptip_mark" id="NUMBER_OF_CITING_PAPERS" onmouseover="HelpTipManager.show_help(this);">?</a>]
+                        <i class="icon-question-sign helptip_mark" id="NUMBER_OF_CITING_PAPERS"></i>
 						</td>
 						<td>
 							{{results['all stats']['Number of citing papers']}}
@@ -193,7 +193,7 @@
 				<tr>
 					<td>Total citations</td>
 					<td class="helptip">
-						[<a class="helptip_mark" id="TOTAL_CITATIONS" onmouseover="HelpTipManager.show_help(this);">?</a>]
+                        <i class="icon-question-sign helptip_mark" id="TOTAL_CITATIONS"></i>
 					</td>
 					<td>
 						{{results['all stats']['Total citations']}}
@@ -208,7 +208,7 @@
 					<tr>
 						<td>Average citations</td>
 						<td class="helptip">
-							[<a class="helptip_mark" id="AVERAGE_CITATIONS" onmouseover="HelpTipManager.show_help(this);">?</a>]
+                        <i class="icon-question-sign helptip_mark" id="AVERAGE_CITATIONS"></i>
 						</td>
 						<td>
 							{{results['all stats']['Average citations']}}
@@ -220,7 +220,7 @@
 					<tr>
 						<td>Median citations</td>
 						<td class="helptip">
-							[<a class="helptip_mark" id="MEDIAN_CITATIONS" onmouseover="HelpTipManager.show_help(this);">?</a>]
+                        <i class="icon-question-sign helptip_mark" id="MEDIAN_CITATIONS"></i>
 						</td>
 						<td>
 							{{results['all stats']['Median citations']}}
@@ -233,7 +233,7 @@
 				<tr>
 					<td>Normalized citations</td>
 					<td class="helptip">
-						[<a class="helptip_mark" id="NORMALIZED_CITATIONS" onmouseover="HelpTipManager.show_help(this);">?</a>]
+                        <i class="icon-question-sign helptip_mark" id="NORMALIZED_CITATIONS"></i>
 					</td>
 					<td>
 						{{results['all stats']['Normalized citations']}}
@@ -247,7 +247,7 @@
 				<tr>
 					<td>Refereed citations</td>
 					<td class="helptip">
-						[<a class="helptip_mark" id="REFEREED_CITATIONS" onmouseover="HelpTipManager.show_help(this);">?</a>]
+                        <i class="icon-question-sign helptip_mark" id="REFEREED_CITATIONS"></i>
 					</td>
 					<td>
 						{{results['all stats']['Refereed citations']}}
@@ -262,7 +262,7 @@
 					<tr>
 						<td>Average refereed citations</td>
 						<td class="helptip">
-							[<a class="helptip_mark" id="AVERAGE_REFEREED_CITATIONS" onmouseover="HelpTipManager.show_help(this);">?</a>]
+                        <i class="icon-question-sign helptip_mark" id="AVERAGE_REFEREED_CITATIONS"></i>
 						</td>
 						<td>
 							{{results['all stats']['Average refereed citations']}}
@@ -274,7 +274,7 @@
 					<tr>
 						<td>Median refereed citations</td>
 						<td class="helptip">
-							[<a class="helptip_mark" id="MEDIAN_REFEREED_CITATIONS" onmouseover="HelpTipManager.show_help(this);">?</a>]
+                        <i class="icon-question-sign helptip_mark" id="MEDIAN_REFEREED_CITATIONS"></i>
 						</td>
 						<td>
 							{{results['all stats']['Median refereed citations']}}
@@ -286,7 +286,7 @@
 					<tr>
 						<td>Normalized refereed citations</td>
 						<td class="helptip">
-							[<a class="helptip_mark" id="NORMALIZED_REFEREED_CITATIONS" onmouseover="HelpTipManager.show_help(this);">?</a>]
+                        <i class="icon-question-sign helptip_mark" id="NORMALIZED_REFEREED_CITATIONS"></i>
 						</td>
 						<td>
 							{{results['all stats']['Normalized refereed citations']}}
@@ -307,7 +307,7 @@
 					<tr>
 						<td>h-index</td>
 						<td class="helptip">
-							[<a class="helptip_mark" id="H_INDEX" onmouseover="HelpTipManager.show_help(this);">?</a>]
+                        <i class="icon-question-sign helptip_mark" id="H_INDEX"></i>
 						</td>
 						<td>
 							{{results['all stats']['H-index']}}
@@ -319,7 +319,7 @@
 					<tr>
 						<td>g-index</td>
 						<td class="helptip">
-							[<a class="helptip_mark" id="G_INDEX" onmouseover="HelpTipManager.show_help(this);">?</a>]
+                        <i class="icon-question-sign helptip_mark" id="G_INDEX"></i>
 						</td>
 						<td>
 							{{results['all stats']['g-index']}}
@@ -331,7 +331,7 @@
 					<tr>
 						<td>i10-index</td>
 						<td class="helptip">
-							[<a class="helptip_mark" id="I10_INDEX" onmouseover="HelpTipManager.show_help(this);">?</a>]
+                        <i class="icon-question-sign helptip_mark" id="I10_INDEX"></i>
 						</td>
 						<td>
 							{{results['all stats']['i10-index']}}
@@ -343,7 +343,7 @@
 					<tr>
 						<td>i100-index</td>
 						<td class="helptip">
-							[<a class="helptip_mark" id="I100_INDEX" onmouseover="HelpTipManager.show_help(this);">?</a>]
+                        <i class="icon-question-sign helptip_mark" id="I100_INDEX"></i>
 						</td>
 						<td>
 							{{results['all stats']['i100-index']}}
@@ -355,7 +355,7 @@
 					<tr>
 						<td>tori index</td>
 						<td class="helptip">
-							[<a class="helptip_mark" id="TORI_INDEX" onmouseover="HelpTipManager.show_help(this);">?</a>]
+                        <i class="icon-question-sign helptip_mark" id="TORI_INDEX"></i>
 						</td>
 						<td>
 							{{results['all stats']['tori index']}}
@@ -367,7 +367,7 @@
 					<tr>
 						<td>riq index</td>
 						<td class="helptip">
-							[<a class="helptip_mark" id="ROQ_INDEX" onmouseover="HelpTipManager.show_help(this);">?</a>]
+                        <i class="icon-question-sign helptip_mark" id="ROQ_INDEX"></i>
 						</td>
 						<td>
 							{{results['all stats']['roq index']}}
@@ -379,7 +379,7 @@
 					<tr>
 						<td>read10-index</td>
 						<td class="helptip">
-							[<a class="helptip_mark" id="READ10_INDEX" onmouseover="HelpTipManager.show_help(this);">?</a>]
+                        <i class="icon-question-sign helptip_mark" id="READ10_INDEX"></i>
 						</td>
 						<td>
 							{{results['all stats']['read10 index']}}


### PR DESCRIPTION
Help tooltips for the metrics overview are now working. The help text, together with the tooltip machinery (based on the bootstrap 'popover' widget) are in 'tooltips.js' in the local static directory for 'bibutils'. The solution right now is not ideal. Essentially it works as follows: the metrics overview has entries like

  <a class="helptip_mark" id="NUMBER_OF_PAPERS" onmouseover="HelpTipManager.show_help(this);">?</a>

calling 'show_help' in 'helptips.js', which then does

HelpTipManager.show_help = function(item)
{
    // Get the help text
    var text_type = this.help_text[item.id];
    // Create the Help tip using popover from bootstrap
    $(item).popover({
        html: true,
        trigger: "hover focus",
        title: text_type['title'],
        content: text_type['help'],
    });
};

getting the relevant text from

HelpTipManager.help_text['NUMBER_OF_PAPERS'] = {'title':'Number of papers', 'help':'The total number of papers'};

However, if you do this, the help tooltip only appears at the second hover. Adding the other '$(document).ready(function(){' function make the tooltips appear immediately.
