### PR TITLE
testing that all tour step selectors find page elements

### DIFF
--- a/adsabs/static/js/adstour.js
+++ b/adsabs/static/js/adstour.js
@@ -350,9 +350,9 @@ var tourSteps = {
 			    placement:'bottom'
 				},
 				{
-				element: "dt:contains(Full Text Sources)", 
-			    title: "Full Text Sources", 
-			    content: "Find links to the full text here. Open Access resources are indicated by an open lock.",
+				element: "#abstractRightMenu dl", 
+			    title: "Full Text & Data Products", 
+			    content: "If an article has associated links to fulltext or data products they will appear here. Open Access resources are indicated by an open lock.",
 			    placement:'left'
 				},
 				{

--- a/tests/casperjs/test-adstour.js
+++ b/tests/casperjs/test-adstour.js
@@ -1,0 +1,47 @@
+
+
+var baseUrl = 'http://localhost:5000';
+
+function checkSteps() {
+	var currentPath = new Uri(window.location.href).path();
+	console.log("checking tour steps for " + currentPath);
+	adsTour.makeTour(currentPath);
+	
+	// fail if no tour was loaded
+	if (!adsTour.tour._steps.length) return false;
+
+	var found = 0
+	_.each(adsTour.tour._steps, function(step) {
+		var sel = step['element'];
+		console.log("checking '" + sel + "'");
+		if ($(sel).length) {
+			found++;
+		} else {
+			console.log("missing: '" + sel + "'");
+		}
+	});
+	console.log("needed: " + adsTour.tour._steps.length + ", got: " + found);
+	return found == adsTour.tour._steps.length;
+}
+
+casper.test.begin("testing adstour.js steps", {
+	test: function(test) {
+		casper.start(baseUrl + "/", function() {
+			test.assertEval(checkSteps);
+			this.fill('#one_box_search', { q: 'black holes' }, true);
+		});
+		casper.then(function() {
+			test.assertEval(checkSteps);
+		});
+		casper.thenOpen(baseUrl + "/search/classic-search/", function() {
+			test.assertEval(checkSteps);
+		});
+		casper.thenOpen(baseUrl + "/abs/2314ADS..4305...27Q/", function() {
+			test.assertEval(checkSteps);
+		});
+	    casper.run(function() {
+	        test.done();
+	    });
+
+	}
+})

--- a/tests/casperjs_pre.js
+++ b/tests/casperjs_pre.js
@@ -1,0 +1,4 @@
+casper.on('remote.message', function(msg) {
+    this.echo('remote message caught: ' + msg);
+});
+casper.test.done();


### PR DESCRIPTION
These tests make use of the casperjs and phantomjs headless testing frameworks (which appear to be much faster than selenium). To run them you'll need to have those installed. I'm working on a better BEER packaging solution that will make that easier, but in the meantime it doesn't hurt anything to contribute them.
