### PR TITLE
compacting jinja templates leads to mysterious javascript breakage. *sad...

### DIFF
--- a/adsabs/app.py
+++ b/adsabs/app.py
@@ -153,9 +153,6 @@ def _configure_extensions(app):
     app.jinja_env.add_extension('jinja2.ext.do')
     app.jinja_env.add_extension('jinja2.ext.loopcontrols')
     
-    if config.COMPACT_JINJA_TEMPLATES:
-        app.jinja_env.add_extension('jinja2compact.Compact')
-    
     app.logger.debug("initializing solrquery extension")
     solr.init_app(app)
     solr.add_request_adapter('http://', SolrRequestAdapter())

--- a/adsabs/templates/macros/record_list_macros/facets.html
+++ b/adsabs/templates/macros/record_list_macros/facets.html
@@ -217,36 +217,35 @@
 	{% set current_page = resp.get_pagination()['current_page']%}
 	<div class="row-fluid well well-small well-facets">
 		<div class="span11 firstspan">
-			{% for elem in selected_facets %}
-				<span class="appliedFilter">
-					{% if elem[0] == 'bib_f' %}
-						Publication :
-					{% elif elem[0] == 'aut_f' %}
-						Author :
-					{% elif elem[0] == 'key_f' %}
-						Keyword :
-					{% elif elem[0] == 'year_f' %}
-						Year :
-					{% elif elem[0] == 'bibgr_f' %}
-						Bibgroup :
-					{% elif elem[0] == 'grant_f' %}
-						Grant :
-					{% elif elem[0] == 'data_f' %}
-						Data :
-					{% elif elem[0] == 'vizier_f' %}
-						Vizier :
-					{% elif elem[0] == 'db_f' %}
-						Database :
-					{% elif elem[0] == 'prop_f' and ('refereed' in elem[1] or 'notrefereed' in elem[1]) %}
+			{%- for elem in selected_facets -%}
+				<span class="appliedFilter">{%- if elem[0] == 'bib_f' -%}
+						Publication
+					{%- elif elem[0] == 'aut_f' -%}
+						Author
+					{%- elif elem[0] == 'key_f' -%}
+						Keyword
+					{%- elif elem[0] == 'year_f' -%}
+						Year
+					{%- elif elem[0] == 'bibgr_f' -%}
+						Bibgroup
+					{%- elif elem[0] == 'grant_f' -%}
+						Grant
+					{%- elif elem[0] == 'data_f' -%}
+						Data
+					{%- elif elem[0] == 'vizier_f' -%}
+						Vizier
+					{%- elif elem[0] == 'db_f' -%}
+						Database
+					{%- elif elem[0] == 'prop_f' and ('refereed' in elem[1] or 'notrefereed' in elem[1]) -%}
 						{# no string and the actual text is converted using the template filter "format_special_ads_facet_str" #}
-					{% else %}
-						{{ elem[0] }} :
-					{% endif %}
-					{{ elem[1]|format_complex_ads_facet_str|format_ads_facet_str|format_special_ads_facet_str }} 
+					{%- else -%}
+						{{ elem[0] }}
+					{%- endif -%}
+					{{ " : " + elem[1]|format_complex_ads_facet_str|format_ads_facet_str|format_special_ads_facet_str }} 
 					<a href="{{ url_for('search.search') }}?{{ request.query_string|rem_par_url('page')|rem_par_url(elem[0], elem[1]) }}" data-rel="bootstrap_tooltip" 
 					   title="remove &ldquo;{{ elem[1]|format_complex_ads_facet_str|format_ads_facet_str }}&rdquo;"><i class="icon-remove-sign"></i></a>
 				</span>
-			{% endfor %}
+			{%- endfor -%}
 		</div>
 		<div class="span1">
 			{% set base_remove_all = [request.query_string|rem_par_url('page')] %}

--- a/config/config.py
+++ b/config/config.py
@@ -311,7 +311,6 @@ class AppConfig(object):
     #ADSGUT
     MONGODB_SETTINGS= {'HOST': 'mongodb://user:pass@localhost/adsgut', 'DB': 'adsgut'}
     
-    COMPACT_JINJA_TEMPLATES = True
     
 try:
     from local_config import LocalConfig

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,4 +47,3 @@ six>=1.0
 -e git+https://github.com/MongoEngine/mongoengine.git@0.8#egg=mongoengine
 -e git+https://github.com/rahuldave/flask-mongoengine.git#egg=flask-mongoengine
 -e git+https://github.com/rahuldave/mongogut.git#egg=mongogut
-jinja2compact

--- a/tests/casperjs/test-search.js
+++ b/tests/casperjs/test-search.js
@@ -42,7 +42,7 @@ casper.test.begin("testing extra search options", {
 
 		casper.then(function() {
 			console.log(this.fetchText('.appliedFilter'));
-			test.assertExists(x('//span[@class="appliedFilter"][text()="  Database :  astronomy "]'), 'selected database filter applied')
+			test.assertExists(x('//span[@class="appliedFilter"][contains(.,"Database : astronomy")]'), 'selected database filter applied')
 		});
 		
 		casper.then(function() {


### PR DESCRIPTION
... trombine*. Forced to reduce whitespace around the "appliedFilter" items using the old {%- -%} trick.
