### PR TITLE
Ticket 551: allow specification of return format via submission form

### DIFF
--- a/adsabs/modules/bibutils/forms.py
+++ b/adsabs/modules/bibutils/forms.py
@@ -27,6 +27,7 @@ class MetricsInputForm(Form):
     """
     bibcodes = TextAreaField('bibcodes')
     layout = TextField('layout')
+    format = TextField('format')
     current_search_parameters = TextField('current_search_parameters')
     bigquery = TextField('bigquery')
     numRecs = TextField('numRecs')

--- a/adsabs/modules/bibutils/views.py
+++ b/adsabs/modules/bibutils/views.py
@@ -178,6 +178,10 @@ def metrics(**args):
             bibcodes = filter(lambda b: len(b) == 19, map(lambda a: str(a).strip(), form.bibcodes.data.strip().split('\n')))
         except:
             bibcodes = []
+        try:
+            format = form.format.data.strip()
+        except:
+            pass
         list_type = request.values.get('list_type', None)
         if len(bibcodes) == 0:
             try:


### PR DESCRIPTION
Just like with the submission form in ADS Classic, the submission form here should support specification of the return format (so that JSON will be returned using after submitting bibcodes in the submission form). I need this to compare metrics results from ADS 2.0 and Classic.
