### PR TITLE
Use citations in metrics_data for Citation Helper

### DIFF
--- a/adsabs/modules/bibutils/utils.py
+++ b/adsabs/modules/bibutils/utils.py
@@ -44,12 +44,11 @@ class MongoCitationListHarvester(Process):
                 break
             try:
                 pubyear = int(bibcode[:4])
-                cit_collection = adsdata.get_collection('citations')
-                res1 = cit_collection.find_one({'_id': bibcode})
-                if res1:
-                    citations = res1.get('citations',[])
-                else:
-                    citations = cits = ref_cits = non_ref_cits = []
+                doc = adsdata.get_metrics_data(bibcode, manipulate=False)
+                try:
+                    citations = doc.get('citations',[])
+                except:
+                    citations = []
                 self.result_queue.put({'citations':citations})
             except MongoQueryError, e:
                 app.logger.error("Mongo citation list query for %s blew up (%s)" % (bibcode,e))


### PR DESCRIPTION
Since the list of citing papers ('citations') is also present in the 'metrics_data' collection, there is no need to use the 'citations' collection separately. In this way, the 'metrics_data' collection is the _only_ one used to retrieve data from (both by the metrics and the Citation Helper).
