### PR TITLE
The metrics overview now lists the number of self-citations

### DIFF
--- a/adsabs/modules/bibutils/metricsmodels/models.py
+++ b/adsabs/modules/bibutils/metricsmodels/models.py
@@ -156,6 +156,11 @@ class Metrics():
             e = sqrt(sum(citations[:h]) - h*h)
         except:
             e = 'NA'
+        # Get the number of self-citations
+        try:
+            number_of_self_citations = sum(map(lambda a: a['number_of_self_citations'], cls.metrics_data))
+        except:
+            number_of_self_citations = 0
         # get the Tori index
         rn_citations = map(lambda a: a['rn_citations'], cls.metrics_data)
         auth_nums    = map(lambda a: 1.0/float(a['author_num']), cls.metrics_data)
@@ -179,6 +184,7 @@ class Metrics():
         cls.tori = float('%.1f' % round(tori,1))
         cls.riq  = float('%.1f' % round(riq,1))
         cls.read10 = int(round(read10))
+        cls.number_of_self_citations = number_of_self_citations
 
         cls.post_process()
 
@@ -497,6 +503,7 @@ class TotalMetrics(Metrics):
         cls.results['tori index (Total)'] = cls.tori
         cls.results['roq index (Total)'] = cls.riq
         cls.results['read10 index (Total)'] = cls.read10
+        cls.results['self-citations (Total)'] = cls.number_of_self_citations
 
 class RefereedMetrics(Metrics):
     config_data_name = 'refereed_metrics'
@@ -526,6 +533,7 @@ class RefereedMetrics(Metrics):
         cls.results['tori index (Refereed)'] = cls.tori
         cls.results['roq index (Refereed)'] = cls.riq
         cls.results['read10 index (Refereed)'] = cls.read10
+        cls.results['self-citations (Refereed)'] = cls.number_of_self_citations
 
 class PublicationHistogram(Histogram):
     config_data_name = 'publication_histogram'

--- a/adsabs/modules/bibutils/static/js/helptips.js
+++ b/adsabs/modules/bibutils/static/js/helptips.js
@@ -11,6 +11,7 @@ HelpTipManager.help_text['NUMBER_OF_PAPERS'] = {'title':'Number of papers', 'hel
 HelpTipManager.help_text['NORMALIZED_PAPER_COUNT'] = {'title':'Normalized paper count', 'help': 'For a list of N papers (i=1,...N), where N<sub>auth</sub><sup>i</sup> is the number of authors for publication i, the normalized paper count is the sum over 1/N<sub>auth</sub><sup>i</sup>'};
 HelpTipManager.help_text['NUMBER_OF_CITING_PAPERS'] = {'title':'Number of citing papers', 'help': 'Number of unique papers citing the papers in the submitted list.'};
 HelpTipManager.help_text['TOTAL_CITATIONS'] = {'title':'Total citations', 'help': 'The total number of times all papers in the list were cited.'};
+HelpTipManager.help_text['NUMBER_OF_SELF_CITATIONS'] = {'title':'Self citations', 'help': 'The number of citing papers that were also in the list from which the metrics were computed'};
 HelpTipManager.help_text['AVERAGE_CITATIONS'] = {'title':'Average citations', 'help': 'The total number of citations divided by the number of papers.'};
 HelpTipManager.help_text['MEDIAN_CITATIONS'] = {'title':'Median citations', 'help': 'The median of the citation distribution.'};
 HelpTipManager.help_text['NORMALIZED_CITATIONS'] = {'title':'Normalized citations', 'help': 'For a list of N papers (i=1,...N), where N<sub>auth</sub><sup>i</sup> is the number of authors for publication i and C<sub>i</sub> the number of citations that this paper received, the normalized citation count for each article is \

--- a/adsabs/modules/bibutils/templates/metrics_results.html
+++ b/adsabs/modules/bibutils/templates/metrics_results.html
@@ -207,6 +207,20 @@
 				</tr>
 				{% if results['mode'] == 'normal' %}
 					<tr>
+						<td>Number of self-citations</td>
+						<td class="helptip">
+                        <i class="icon-question-sign helptip_mark" id="NUMBER_OF_SELF_CITATIONS"></i>
+						</td>
+						<td>
+							{{results['all stats']['self-citations']}}
+						</td>
+						<td>
+							{{results['refereed stats']['self-citations']}}
+						</td>
+					</tr>
+				{% endif %}
+				{% if results['mode'] == 'normal' %}
+					<tr>
 						<td>Average citations</td>
 						<td class="helptip">
                         <i class="icon-question-sign helptip_mark" id="AVERAGE_CITATIONS"></i>

--- a/adsabs/modules/bibutils/utils.py
+++ b/adsabs/modules/bibutils/utils.py
@@ -109,9 +109,10 @@ def get_metrics_data(**args):
         data = results.get()
         # First remove self-citations for tori data
         try:
-            rn_citations, rn_hist = remove_self_citations(bibcodes,data)
+            rn_citations, rn_hist, n_self = remove_self_citations(bibcodes,data)
             data['rn_citations'] = rn_citations
             data['rn_citations_hist'] = rn_hist
+            data['number_of_self_citations'] = n_self
         except:
             pass
         try:
@@ -125,6 +126,7 @@ def remove_self_citations(biblist,datadict):
     # Remove all the entries in "datadict['rn_citation_data']" where the bibcode is
     # in the supplied list of bibcodes
     result = filter(lambda a: a['bibcode'] not in biblist, datadict['rn_citation_data'])
+    Nself  = len(filter(lambda a: a['bibcode'] in biblist, datadict['rn_citation_data']))
     rn_hist = {}
     for item in result:
         try:
@@ -133,7 +135,7 @@ def remove_self_citations(biblist,datadict):
             rn_hist[item['bibcode'][:4]] = item['ref_norm']
 
     # Now we can aggregate the individual contributions to the overall normalized count
-    return sum(map(lambda a: a['ref_norm'], result)), rn_hist
+    return sum(map(lambda a: a['ref_norm'], result)), rn_hist, Nself
 
 def get_meta_data(**args):
     """


### PR DESCRIPTION
ADS Classic has the ability to remove self-citations when generating a citations list. I realized that it would be a useful number of have this in the metrics overview as well.
