### PR TITLE
ticket_599: citation helper also uses query_components to get bibcodes

### DIFF
--- a/adsabs/modules/bibutils/views.py
+++ b/adsabs/modules/bibutils/views.py
@@ -67,17 +67,16 @@ def citation_helper(**args):
         list_type = request.values.get('list_type', None)
         if len(bibcodes) == 0:
             try:
-                query_par = str(form.current_search_parameters.data.strip())
-                query = json.loads(query_par)['q']
-                sort  = json.loads(query_par).get('sort', None)
+                query_components = json.loads(request.values.get('current_search_parameters'))
+                sort = []
                 bigquery_id = form.bigquery.data
-                if sort is None:
-                    # this might be an abstract citation/reference list view so get the sort from config
-                    if list_type is not None and list_type in config.ABS_SORT_OPTIONS_MAP:
-                        sort = [config.ABS_SORT_OPTIONS_MAP[list_type]]
-                    else:
-                        sort = []
-                bibcodes = get_publications_from_query(query, sort, list_type, bigquery_id)[:number_of_records]
+                query_components.update({
+                    'rows': number_of_records,
+                    'facets': [],
+                    'fields': ['bibcode'],
+                    'highlights': [],
+                })
+                bibcodes = get_publications_from_query(query_components, list_type, bigquery_id)
             except:
                 bibcodes = []
         # no bibcodes? display message and re-display input form


### PR DESCRIPTION
Citation Helper broke because of change in 'get_bibcodes_from_query' function. Fixed.
