### PR TITLE
fix for double public library

### DIFF
--- a/adsabs/modules/adsgut/webservices.py
+++ b/adsabs/modules/adsgut/webservices.py
@@ -323,6 +323,7 @@ def userInfo(nick):
             d['reason'] = ''
         else:
             reasons=[e[1] for e in names[d['fqpn']]]
+            reasons=list(set(reasons))
             #eliminate all libraries (many!) the user is in because
             #os being part of the public group
             #(TODO: might be better done cleaner in membableslibrary)


### PR DESCRIPTION
This is a patch over database inconsistency that showed up when a user added public group to library, removed public group from library, and added again. Tomorrow I'll add some defensive code to check for double existence of this group. In any case, this fix should remain, as its defensive against dupes.
