### PR TITLE
return empty dictionary for records with missing metrics data

### DIFF
--- a/adsabs/modules/bibutils/utils.py
+++ b/adsabs/modules/bibutils/utils.py
@@ -74,9 +74,9 @@ class MetricsDataHarvester(Process):
                 doc = adsdata.get_metrics_data(bibcode, manipulate=False)
                 doc['author_num'] = max(doc['author_num'],1)
                 self.result_queue.put(doc)
-            except MongoQueryError, e:
+            except Exception, e:
                 app.logger.error("Mongo metrics data query for %s blew up (%s)" % (bibcode,e))
-                raise
+                self.result_queue.put({})
         return
 
 def get_metrics_data(**args):


### PR DESCRIPTION
When there is no entry in the metrics_data collection, a query returns None and an exception is thrown when we try to retrieve the attribute 'author_num'. This now results in sending back an empty dictionary, which will result in the bibcode being recorded as missing. The 'raise' caused the thread to hang.